### PR TITLE
Add GitHub Icon with Link to Repo

### DIFF
--- a/src/components/header/Index.vue
+++ b/src/components/header/Index.vue
@@ -25,6 +25,17 @@ export default {
                     <Logo />
                 </div>
 
+                <!-- Github Repo Link -->
+                <div class="hidden md:flex absolute right-0 flex-shrink-0 lg:static text-4xl font-bold text-white" aria-labelledby="githubHeading">
+                    <h2 id="githubHeading" class="sr-only" aria-hidden="true">Github Repo</h2>
+                    <a href="https://github.com/kamst01/typizer/">
+                        <!-- feathericons: github  -->
+                        <svg class="block h-6 w-6" xmlns="http://www.w3.org/2000/svg" width="24" height="24" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round">
+                            <path d="M9 19c-5 1.5-5-2.5-7-3m14 6v-3.87a3.37 3.37 0 0 0-.94-2.61c3.14-.35 6.44-1.54 6.44-7A5.44 5.44 0 0 0 20 4.77 5.07 5.07 0 0 0 19.91 1S18.73.65 16 2.48a13.38 13.38 0 0 0-7 0C6.27.65 5.09 1 5.09 1A5.07 5.07 0 0 0 5 4.77a5.44 5.44 0 0 0-1.5 3.78c0 5.42 3.3 6.61 6.44 7A3.37 3.37 0 0 0 9 18.13V22"></path>
+                        </svg>
+                    </a>
+                </div>
+
                 <!-- Menu button -->
                 <div class="absolute right-0 flex-shrink-0 lg:hidden">
                     <!-- Mobile menu button -->


### PR DESCRIPTION
# Pull Request

Fixes #26 

## Summary
Adds icon with link to repo in the header.

## Changes

- `src/components/header/Index.vue` -
  - add link element to repo
  - fill link element with svg icon of github logo

## Additional Information

### Releveant Documentation
[feather icons](https://feathericons.com/)